### PR TITLE
Feat/detect arch

### DIFF
--- a/jill.sh
+++ b/jill.sh
@@ -68,12 +68,12 @@ function confirm() {
 function download_and_install() {
   mkdir -p $JULIA_DOWNLOAD
   cd $JULIA_DOWNLOAD
-  wget https://julialang.org/downloads/ -O page.html
+  wget --no-check-certificate https://julialang.org/downloads/ -O page.html
   arch="$(lscpu | grep Architecture | cut -d':' -f2 | tr -d '[:space:]')"
-  url=$(grep "https.*linux/$arch.*gz" page.html -m 1 -o)
+  url=$(grep "https.*linux/${arch}.*gz" page.html -m 1 -o)
   [[ $url =~ julia-(.*)-linux ]] && version=${BASH_REMATCH[1]}
   major=${version:0:3}
-  wget -c $url -O julia-$version.tar.gz
+  wget --no-check-certificate -c $url -O julia-$version.tar.gz
   mkdir -p julia-$version
   tar zxf julia-$version.tar.gz -C julia-$version --strip-components 1
 

--- a/jill.sh
+++ b/jill.sh
@@ -68,12 +68,12 @@ function confirm() {
 function download_and_install() {
   mkdir -p $JULIA_DOWNLOAD
   cd $JULIA_DOWNLOAD
-  wget --no-check-certificate https://julialang.org/downloads/ -O page.html
+  wget https://julialang.org/downloads/ -O page.html
   arch="$(lscpu | grep Architecture | cut -d':' -f2 | tr -d '[:space:]')"
   url=$(grep "https.*linux/${arch}.*gz" page.html -m 1 -o)
   [[ $url =~ julia-(.*)-linux ]] && version=${BASH_REMATCH[1]}
   major=${version:0:3}
-  wget --no-check-certificate -c $url -O julia-$version.tar.gz
+  wget -c $url -O julia-$version.tar.gz
   mkdir -p julia-$version
   tar zxf julia-$version.tar.gz -C julia-$version --strip-components 1
 

--- a/jill.sh
+++ b/jill.sh
@@ -70,12 +70,7 @@ function download_and_install() {
   cd $JULIA_DOWNLOAD
   wget https://julialang.org/downloads/ -O page.html
   arch="$(lscpu | grep Architecture | cut -d':' -f2 | tr -d '[:space:]')" 
-  echo "$(lscpu)" 
-  echo "$(lscpu | grep Architecture)" 
-  echo "$(lscpu | grep Architecture | cut -d':' -f2)" 
-  echo "$(lscpu | grep Architecture | cut -d':' -f2 | tr -d '[:space:]')" 
-  echo "$arch"
-  url=$(grep "https.*linux/${arch}.*gz" page.html -m 1 -o)
+  url=$(grep "https.*linux/.*${arch}.*gz" page.html -m 1 -o)
   [[ $url =~ julia-(.*)-linux ]] && version=${BASH_REMATCH[1]}
   major=${version:0:3}
   wget -c $url -O julia-$version.tar.gz

--- a/jill.sh
+++ b/jill.sh
@@ -69,7 +69,12 @@ function download_and_install() {
   mkdir -p $JULIA_DOWNLOAD
   cd $JULIA_DOWNLOAD
   wget https://julialang.org/downloads/ -O page.html
-  arch="$(lscpu | grep Architecture | cut -d':' -f2 | tr -d '[:space:]')"
+  arch="$(lscpu | grep Architecture | cut -d':' -f2 | tr -d '[:space:]')" 
+  echo "$(lscpu)" 
+  echo "$(lscpu | grep Architecture)" 
+  echo "$(lscpu | grep Architecture | cut -d':' -f2)" 
+  echo "$(lscpu | grep Architecture | cut -d':' -f2 | tr -d '[:space:]')" 
+  echo "$arch"
   url=$(grep "https.*linux/${arch}.*gz" page.html -m 1 -o)
   [[ $url =~ julia-(.*)-linux ]] && version=${BASH_REMATCH[1]}
   major=${version:0:3}

--- a/jill.sh
+++ b/jill.sh
@@ -1,4 +1,4 @@
-#! /bin/sh
+#/usr/bin/env sh
 #
 # jill.sh
 # Copyright (C) 2017 Abel Soares Siqueira <abel.s.siqueira@gmail.com>
@@ -69,7 +69,8 @@ function download_and_install() {
   mkdir -p $JULIA_DOWNLOAD
   cd $JULIA_DOWNLOAD
   wget https://julialang.org/downloads/ -O page.html
-  url=$(grep "https.*linux/x64.*gz" page.html -m 1 -o)
+  arch="$(lscpu | grep Architecture | cut -d':' -f2 | tr -d '[:space:]')"
+  url=$(grep "https.*linux/$arch.*gz" page.html -m 1 -o)
   [[ $url =~ julia-(.*)-linux ]] && version=${BASH_REMATCH[1]}
   major=${version:0:3}
   wget -c $url -O julia-$version.tar.gz


### PR DESCRIPTION
This PR:
1) Changes the shebang line to make the script more portable
2) Automatically detects the architecture of the machine where the script is executed (versus hardcoding x64_86)

Tested on Ubuntu 18.10 x86_04 and nvidia Jetson TX2 running Ubuntu 16.04 (aarch64 architecture).