### PR TITLE
fix permission error

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,5 +7,5 @@ os:
 sudo: required
 
 script:
-  - echo "y" | bash jill.sh
+  - echo "yy" | bash jill.sh
   - julia -v

--- a/README.md
+++ b/README.md
@@ -15,16 +15,17 @@ Simply run
 
     bash -ci "$(curl -fsSL https://raw.githubusercontent.com/abelsiqueira/jill/master/jill.sh)"
 
-installs Julia into `$HOME/.local/bin`
+installs Julia into `$HOME/.local/bin`.
 
-If you want to install Julia system-wide, you can add an `sudo` prefix, i.e.,
+If you want to install Julia system-wide, you can add an `sudo` prefix
 
     sudo bash -ci "$(curl -fsSL https://raw.githubusercontent.com/abelsiqueira/jill/master/jill.sh)"
 
-If you want to install to other places, create a folder, add it to your PATH
-and then issue
+If you want to install to other places, you can specify the `JULIA_DOWNLOAD` and `JULIA_INSTALL` folder
 
     JULIA_DOWNLOAD=downloadfolder JULIA_INSTALL=linkfolder bash -ci "$(curl -fsSL https://raw.githubusercontent.com/abelsiqueira/jill/master/jill.sh)"
+
+The script will then download Julia in `JULIA_DOWNLOAD` and make a link to `JULIA_INSTALL`.
 
 To download a specific supported version, use
 

--- a/README.md
+++ b/README.md
@@ -15,10 +15,16 @@ Simply run
 
     bash -ci "$(curl -fsSL https://raw.githubusercontent.com/abelsiqueira/jill/master/jill.sh)"
 
-If you want to avoid using sudo, create a folder, add it to your PATH
+installs Julia into `$HOME/.local/bin`
+
+If you want to install Julia system-wide, you can add an `sudo` prefix, i.e.,
+
+    sudo bash -ci "$(curl -fsSL https://raw.githubusercontent.com/abelsiqueira/jill/master/jill.sh)"
+
+If you want to install to other places, create a folder, add it to your PATH
 and then issue
 
-    JULIA_INSTALL=yourfolder bash -ci "$(curl -fsSL https://raw.githubusercontent.com/abelsiqueira/jill/master/jill.sh)"
+    JULIA_DOWNLOAD=downloadfolder JULIA_INSTALL=linkfolder bash -ci "$(curl -fsSL https://raw.githubusercontent.com/abelsiqueira/jill/master/jill.sh)"
 
 To download a specific supported version, use
 

--- a/jill.sh
+++ b/jill.sh
@@ -42,7 +42,6 @@ function badfolder() {
     echo "Aborted"
     exit 1
   else
-    mkdir -p $JULIA_INSTALL
     echo 'export PATH="'"$JULIA_INSTALL"':$PATH"' | tee -a ~/.bashrc
     echo ""
     echo "run 'source ~/.bashrc' or restart your bash to reload the PATH"
@@ -55,6 +54,7 @@ function hi() {
   if [[ ! ":$PATH:" == *":$JULIA_INSTALL:"* ]]; then
     badfolder
   fi
+  mkdir -p $JULIA_INSTALL # won't create if it's aborted earlier
   echo "This script will:"
   echo ""
   # TODO: Expand to install older Julia?
@@ -69,7 +69,7 @@ function hi() {
     echo "Download folder will be created if required"
   fi
   if [ ! -w $JULIA_INSTALL ]; then
-    echo "You don't have write permission to $JULIA_INSTALL or the dir doesn't exist"
+    echo "You don't have write permission to $JULIA_INSTALL."
     exit 1
   fi
 }

--- a/jill.sh
+++ b/jill.sh
@@ -17,8 +17,13 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-JULIA_DOWNLOAD=${JULIA_DOWNLOAD:-"$HOME/packages/julias"}
-JULIA_INSTALL=${JULIA_INSTALL:-"/usr/local/bin"}
+if [[ "$(whoami)" == "root" ]]; then
+  JULIA_DOWNLOAD=${JULIA_DOWNLOAD:-"/opt/julias"}
+  JULIA_INSTALL=${JULIA_INSTALL:-"/usr/local/bin"}
+else
+  JULIA_DOWNLOAD=${JULIA_DOWNLOAD:-"$HOME/packages/julias"}
+  JULIA_INSTALL=${JULIA_INSTALL:-"$HOME/.local/bin"}
+fi
 
 function header() {
   echo "Jill - Julia Installer 4 Linux (and MacOS) - Light"
@@ -52,7 +57,8 @@ function hi() {
     echo "Download folder will be created if required"
   fi
   if [ ! -w $JULIA_INSTALL ]; then
-    echo "You'll be asked for your sudo password to install on $JULIA_INSTALL"
+    echo "You don't have write permission to $JULIA_INSTALL"
+    exit 1
   fi
 }
 
@@ -88,14 +94,11 @@ function install_julia_linux() {
   mkdir -p julia-$version
   tar zxf julia-$version.tar.gz -C julia-$version --strip-components 1
 
-  if [ ! -w $JULIA_INSTALL ]; then
-    SUDO=sudo
-  fi
-  $SUDO rm -f $JULIA_INSTALL/julia{,-$major,-$version}
+  rm -f $JULIA_INSTALL/julia{,-$major,-$version}
   julia=$PWD/julia-$version/bin/julia
-  $SUDO ln -s $julia $JULIA_INSTALL/julia
-  $SUDO ln -s $julia $JULIA_INSTALL/julia-$major
-  $SUDO ln -s $julia $JULIA_INSTALL/julia-$version
+  ln -s $julia $JULIA_INSTALL/julia
+  ln -s $julia $JULIA_INSTALL/julia-$major
+  ln -s $julia $JULIA_INSTALL/julia-$version
 }
 
 function install_julia_mac() {

--- a/jill.sh
+++ b/jill.sh
@@ -35,13 +35,25 @@ function badfolder() {
   echo "The folder '$JULIA_INSTALL' is not on your PATH, you can"
   echo "- 1) Add it to your path; or"
   echo "- 2) Run 'JULIA_INSTALL=otherfolder ./jill.sh'"
+
+  read -p "Do you want to add '$JULIA_INSTALL' into your PATH? (Y/N) " -n 1 -r
+  echo
+  if [[ ! $REPLY =~ ^[Yy] ]]; then
+    echo "Aborted"
+    exit 1
+  else
+    mkdir -p $JULIA_INSTALL
+    echo 'export PATH="'"$JULIA_INSTALL"':$PATH"' | tee -a ~/.bashrc
+    echo ""
+    echo "run 'source ~/.bashrc' or restart your bash to reload the PATH"
+    echo ""
+  fi
 }
 
 function hi() {
   header
   if [[ ! ":$PATH:" == *":$JULIA_INSTALL:"* ]]; then
     badfolder
-    exit 1
   fi
   echo "This script will:"
   echo ""
@@ -57,7 +69,7 @@ function hi() {
     echo "Download folder will be created if required"
   fi
   if [ ! -w $JULIA_INSTALL ]; then
-    echo "You don't have write permission to $JULIA_INSTALL"
+    echo "You don't have write permission to $JULIA_INSTALL or the dir doesn't exist"
     exit 1
   fi
 }


### PR DESCRIPTION
Other users aren't able to use `julia` since in most cases they don't have permission to access my `$HOME/packages/julias`.

This patch enables the following behaviors:

* `sudo bash jill.sh` installs Julia system-wide
* `bash jill.sh` installs Julia into user's home folder (not affecting others)

~Ask: should I add `$HOME/.local/bin` to `PATH` when it's not in `PATH` or keep it unchanged?~