### PR TITLE
Update the jill title

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Jill - Julia Installer 4 Linux (and MacOS) - Light
+# JILL - Julia Installer 4 Linux (and MacOS) - Light
 
 [![Build
 Status](https://travis-ci.org/abelsiqueira/jill.svg?branch=master)](https://travis-ci.org/abelsiqueira/jill)

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# JILL - Julia Installer 4 Linux - Light
+# Jill - Julia Installer 4 Linux (and MacOS) - Light
 
 [![Build
 Status](https://travis-ci.org/abelsiqueira/jill.svg?branch=master)](https://travis-ci.org/abelsiqueira/jill)

--- a/jill.sh
+++ b/jill.sh
@@ -17,11 +17,15 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+# For Linux, this script installs Julia into $JULIA_DOWNLOAD and make a
+# link to $JULIA_INSTALL
+# For MacOS, this script installs Julia into /Applications and make a
+# link to $JULIA_INSTALL
 JULIA_DOWNLOAD=${JULIA_DOWNLOAD:-"$HOME/packages/julias"}
 JULIA_INSTALL=${JULIA_INSTALL:-"/usr/local/bin"}
 
 function header() {
-  echo "Jill - Julia Installer 4 Linux (and MacOS) - Light"
+  echo "JILL - Julia Installer 4 Linux (and MacOS) - Light"
   echo "Copyright (C) 2017 Abel Soares Siqueira <abel.s.siqueira@gmail.com>"
   echo "Distributed under terms of the GPLv3 license."
 }


### PR DESCRIPTION
I forgot to update the README title in #8, now jill should be interpreted as "Julia Installer 4 Linux (and MacOS) - Light" then 😄