### PR TITLE
:memo: Update CHANGELOG for v0.7.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [unreleased]
 
+## [0.7.1] - 2026-09-02
+
+### Changed
+
+- Julia LTS changed to 1.10.12
+
+## [0.7.0] - 2025-10-15
+
+### Changed
+
+- Julia latest changed to 1.12
+
 ## [0.6.0] - 2024-10-09
 
 ### Changed
@@ -105,7 +117,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 We didn't follow semantic versioning before, so this first tag has 4 years of work attached to it.
 
-[unreleased]: https://github.com/abelsiqueira/jill/compare/v0.6.0...HEAD
+[unreleased]: https://github.com/abelsiqueira/jill/compare/v0.7.1...HEAD
+[0.7.1]: https://github.com/abelsiqueira/jill/releases/tag/v0.7.1
+[0.7.0]: https://github.com/abelsiqueira/jill/releases/tag/v0.7.0
 [0.6.0]: https://github.com/abelsiqueira/jill/releases/tag/v0.6.0
 [0.5.3]: https://github.com/abelsiqueira/jill/releases/tag/v0.5.3
 [0.5.2]: https://github.com/abelsiqueira/jill/releases/tag/v0.5.2


### PR DESCRIPTION
Prepares the v0.7.1 release:

- Adds `0.7.1` with the Julia LTS bump to 1.10.12 (covers 1.10.10 -> 1.10.12 since the last release).
- Backfills the missing `0.7.0` entry (Julia latest changed to 1.12), which was never recorded when that release was cut.
- Fixes the link section: `unreleased` now compares against `v0.7.1`, and adds the `0.7.1`/`0.7.0` tag links.

🤖 Generated with [Claude Code](https://claude.com/claude-code)