### PR TITLE
:construction_worker: Exclude Zenodo badge URL from link checker

### DIFF
--- a/.lychee.toml
+++ b/.lychee.toml
@@ -1,7 +1,9 @@
 exclude = [
   "@ref",
   "^https://github.com/.*/releases/tag/v.*$",
-  "^https://github.com/.*/compare/v.*HEAD$"
+  "^https://github.com/.*/compare/v.*HEAD$",
+  # Zenodo's badge endpoint is unreliable: intermittent timeouts and 502s
+  "^https://zenodo.org/badge/.*$"
 ]
 
 exclude_path = [


### PR DESCRIPTION
The Zenodo badge URL in the README has failed the link checker twice in a row on two different runs, in two different ways:

- `[TIMEOUT] https://zenodo.org/badge/latestdoi/110103530?style=flat-square | Request timed out` (on #135)
- `[502] ... | Rejected status code: 502 Bad Gateway` (on #134)

Both were unrelated to the changes under test. Excluding the badge endpoint stops it from blocking unrelated pull requests.

No CHANGELOG entry: the repo does not track CI-only changes there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)